### PR TITLE
pip install のためのpyproject.toml追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ This repository provides a pre-trained model for extracting the [x-vector](https
 - Other configurations: followed the ASV recipe for VoxCeleb in Kaldi.
   - In the opensourced model, model parameters of recognition layers following to the x-vector layer were randomized to protect data privacy.
 
+## Installation
+```bash
+pip install xvector-jtubespeech
+```
+
 ## Usage / 使い方
 ```
 import numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name="xvector_jtubespeech"
+version="0.0.1"
+description="Pre-trained model for extracting the x-vector (speaker representation vector)"
+readme="README.md"
+
+dependencies = [
+  "numpy>=1.22.3",
+  "scipy>=1.8.0",
+  "torch>=1.10.2",
+  "torchaudio>=0.10.2"
+]
+
+[tool.hatch.build.targets.xvector_jtubespeech]
+[build-system]
+requires=["hatchling"]
+build-backend= "hatchling.build"
+[tool.hatch.build]
+sources = ["xvector_jtubespeech"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,12 @@
+[build-system]
+requires=["hatchling"]
+build-backend= "hatchling.build"
 [project]
 name="xvector_jtubespeech"
 version="0.0.1"
 description="Pre-trained model for extracting the x-vector (speaker representation vector)"
 readme="README.md"
+requires-python=">=3.8"
 
 dependencies = [
   "numpy>=1.22.3",
@@ -12,8 +16,5 @@ dependencies = [
 ]
 
 [tool.hatch.build.targets.xvector_jtubespeech]
-[build-system]
-requires=["hatchling"]
-build-backend= "hatchling.build"
 [tool.hatch.build]
-sources = ["xvector_jtubespeech"]
+include = ["xvector_jtubespeech/"]


### PR DESCRIPTION
```
pip install xvector_jtubespeech
```
といったようにインストールするために必要なpyproject.tomlを追加しました．
これにより，簡便なインストールが可能になります．
また，READMEにinstallのためのコマンドを追記しました．マージされ次第pypi に登録します．